### PR TITLE
Fix for issue #41

### DIFF
--- a/src/config/openai.php
+++ b/src/config/openai.php
@@ -14,5 +14,6 @@ return [
 
     'api_key' => env('OPENAI_API_KEY'),
     'organization' => env('OPENAI_ORGANIZATION'),
+    'base_uri' => env('OPENAI_API_BASE_URI', 'https://api.openai.com/v1'),
 
 ];


### PR DESCRIPTION
This change adds a configurable `base_uri` option to the OpenAI configuration, defaulting to the official API. By setting `OPENAI_API_BASE_URI` in your environment (for example, pointing to `http://localhost:11434` for a locally hosted Ollama server), you can now direct chat and other OpenAI requests to a self-hosted Ollama endpoint without modifying existing code.

Closes #41