### PR TITLE
Fix for issue #33

### DIFF
--- a/src/config/ai.php
+++ b/src/config/ai.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'engine' => env('AI_ENGINE', 'openai'),
+
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+
+    'llama' => [
+        'base_url' => env('LLAMA_API_URL'),
+        'api_key' => env('LLAMA_API_KEY'),
+    ],
+];


### PR DESCRIPTION
This PR introduces support for selecting a custom AI engine (e.g., self-hosted Llama) alongside OpenAI. Key changes:

1. Created config/ai.php to define the active engine (AI_ENGINE) and credentials/settings for both OpenAI and Llama endpoints.
2. Added App\Services\AiService to abstract chat and audio transcription calls. It delegates to the configured engine: OpenAI via the existing facade, or Llama via HTTP requests.
3. Updated all AI-related Actions (GenerateSubtitles, TranslateSubtitles, GenerateChapters, GenerateSummary) to inject and use AiService instead of directly calling the OpenAI facade.

With these changes, you can now set AI_ENGINE=openai or AI_ENGINE=llama in your .env (along with LLAMA_API_URL and LLAMA_API_KEY) to switch between providers seamlessly.

Closes #33