### PR TITLE
Fix for issue #33

### DIFF
--- a/src/app/Actions/GenerateChapters.php
+++ b/src/app/Actions/GenerateChapters.php
@@ -4,9 +4,10 @@ namespace App\Actions;
 
 use App\Enums\Status;
 use App\Models\Process;
-use OpenAI\Laravel\Facades\OpenAI;
+use App\Services\AiService;
 
 class GenerateChapters
+    public function __construct(protected AiService $ai) {}
 {
     public function handle(Process $process, \Closure $next)
     {
@@ -24,12 +25,35 @@ class GenerateChapters
         try {
             $completedChapterChunks = [];
 
-            foreach($process->transcriptChunks as $chunk) {
-                $completedChapterChunks[] = $this->getChapters($chunk, $chaptersAmount);
-            }
+    private function getChapters($subtitles, $chaptersAmount)
+    {
+        $response = $this->ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'temperature' => 0.2,
+            'messages' => [
+                ['role' => 'system', 'content' => "You are a video editor. You will be given subtitles of a video. You need to summarize the video as a list of {$chaptersAmount} concise chapters, no more than a short sentence each. Each chapter should be prefixed with a single timestamp relevant to the starting position in the video. Provide back only the list of chapters, nothing before and nothing after."],
+    private function getCompiledChapters($chapterChunks, $chaptersAmount)
+    {
+        $response = $this->ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'temperature' => 0.2,
+            'messages' => [
+                ['role' => 'system', 'content' => "You are a video editor. You will be given a list of chapters for a video. You need to reduce this list down to just {$chaptersAmount} chapters, spread out evenly throughout the entire original list. Keep the relevant, singular, timestamp from the beginning of the original chapter. Provide back only the list of chapters, nothing before and nothing after."],
+                ['role' => 'user', 'content' => implode(' ', $chapterChunks)],
+            ],
+        ]);
 
-            $completedChapters = $this->getCompiledChapters($completedChapterChunks, $chaptersAmount);
+        $compiled = '';
+        foreach (($response->choices ?? $response['choices']) as $choice) {
+            $compiled .= $choice->message->content ?? $choice['message']['content'];
+        }
 
+        return $compiled;
+    }
+        }
+
+        return $completedChapters;
+    }
             $process->update([
                 'chapters' => $completedChapters
             ]);

--- a/src/app/Actions/GenerateSubtitles.php
+++ b/src/app/Actions/GenerateSubtitles.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace App\Actions;
-
 use App\Enums\Status;
 use App\Models\Process;
+use App\Services\AiService;
 use OpenAI\Laravel\Facades\OpenAI;
 
 class GenerateSubtitles
+    public function __construct(protected AiService $ai) {}
 {
     public function handle(Process $process, \Closure $next)
     {
@@ -24,10 +25,17 @@ class GenerateSubtitles
             $process->update([
                 'transcript' => $transcript->text
             ]);
-        } catch (\Exception $e) {
+        try {
+            $transcript = $this->ai->audioTranscribe([
+                'model' => 'whisper-1',
+                'file' => fopen(storage_path("app/audio/{$process->id}.mp3"), 'r'),
+                'response_format' => 'vtt',
+            ]);
+
             $process->update([
-                'status' => Status::ERRORED,
-                'error' => $e->getMessage(),
+                'transcript' => is_object($transcript) ? $transcript->text : ($transcript['text'] ?? ''),
+            ]);
+        } catch (\Exception $e) {
             ]);
 
             return;

--- a/src/app/Actions/GenerateSummary.php
+++ b/src/app/Actions/GenerateSummary.php
@@ -4,9 +4,10 @@ namespace App\Actions;
 
 use App\Enums\Status;
 use App\Models\Process;
-use OpenAI\Laravel\Facades\OpenAI;
+use App\Services\AiService;
 
 class GenerateSummary
+    public function __construct(protected AiService $ai) {}
 {
     public function handle(Process $process, \Closure $next)
     {
@@ -24,13 +25,34 @@ class GenerateSummary
 
             foreach($process->transcriptChunks as $chunk) {
                 $completedSummaryChunks[] = $this->getSummary($chunk);
-            }
+    private function getSummary($subtitles)
+    {
+        $response = $this->ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'temperature' => 0.2,
+            'messages' => [
+                ['role' => 'system', 'content' => 'You are a video editor. You will be given subtitles of a video. You need to summarize the video in a concise manner, as a single paragraph, and no more than 5 sentences. Provide back only the summary text, nothing before and nothing after.'],
+                ['role' => 'user', 'content' => implode("\n", $subtitles)],
+    private function getCompiledSummary($summaryChunks)
+    {
+        $response = $this->ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'temperature' => 0.2,
+            'messages' => [
+                ['role' => 'system', 'content' => 'You are a video editor. You will be given a large summary of a video. You need to condense this summary down in a concise manner, as a single paragraph, and no more than 5 sentences. Provide back only the summary text, nothing before and nothing after.'],
+                ['role' => 'user', 'content' => implode(' ', $summaryChunks)],
+            ],
+        ]);
 
-            $completedSummary = $this->getCompiledSummary($completedSummaryChunks);
+        $compiled = '';
+        foreach (($response->choices ?? $response['choices']) as $choice) {
+            $compiled .= $choice->message->content ?? $choice['message']['content'];
+        }
 
-            $process->update([
-                'summary' => $completedSummary
-            ]);
+        return $compiled;
+    }
+        return $completed;
+    }
         } catch (\Exception $e) {
             $process->update([
                 'status' => Status::ERRORED,

--- a/src/app/Actions/TranslateSubtitles.php
+++ b/src/app/Actions/TranslateSubtitles.php
@@ -4,9 +4,10 @@ namespace App\Actions;
 
 use App\Enums\Status;
 use App\Models\Process;
-use OpenAI\Laravel\Facades\OpenAI;
+use App\Services\AiService;
 
 class TranslateSubtitles
+    public function __construct(protected AiService $ai) {}
 {
     public function handle(Process $process, \Closure $next)
     {
@@ -36,11 +37,23 @@ class TranslateSubtitles
 
             return;
         }
-
-        return $next($process);
-    }
-
     private function translateChunk($chunk, $language)
+    {
+        $response = $this->ai->chat([
+            'model' => 'gpt-3.5-turbo',
+            'messages' => [
+                ['role' => 'system', 'content' => "Translate the vtt subtitles provided to {$language}. Provide back the translated vtt file, including the original timestamps."],
+                ['role' => 'user', 'content' => implode("\n", $chunk)],
+            ],
+        ]);
+
+        $completedTranslation = '';
+        foreach (($response->choices ?? $response['choices']) as $choice) {
+            $completedTranslation .= $choice->message->content ?? $choice['message']['content'];
+        }
+
+        return $completedTranslation;
+    }
     {
         $summary = OpenAI::chat()->create([
             'model' => 'gpt-3.5-turbo',

--- a/src/app/Services/AiService.php
+++ b/src/app/Services/AiService.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class AiService
+{
+    public function chat(array $options)
+    {
+        if (config('ai.engine') === 'openai') {
+            return OpenAI::chat()->create($options);
+        }
+
+        // Llama-compatible chat endpoint
+        $response = Http::withHeaders([
+            'Authorization' => 'Bearer '.config('ai.llama.api_key'),
+        ])->post(rtrim(config('ai.llama.base_url'), '/').'/v1/chat/completions', $options);
+
+        return json_decode($response->body(), true);
+    }
+
+    public function audioTranscribe(array $options)
+    {
+        if (config('ai.engine') === 'openai') {
+            return OpenAI::audio()->transcribe($options);
+        }
+
+        // Llama-compatible audio transcription stub
+        $response = Http::withHeaders([
+            'Authorization' => 'Bearer '.config('ai.llama.api_key'),
+        ])
+        ->attach('file', fopen(storage_path('app/audio/'.$options['model'] ?? '').'', 'r'))
+        ->post(rtrim(config('ai.llama.base_url'), '/').'/v1/audio/transcriptions', $options);
+
+        return json_decode($response->body(), true);
+    }
+}

--- a/src/config/ai.php
+++ b/src/config/ai.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'engine' => env('AI_ENGINE', 'openai'),
+
+    'openai' => [
+        'api_key' => env('OPENAI_API_KEY'),
+        'organization' => env('OPENAI_ORGANIZATION'),
+    ],
+
+    'llama' => [
+        'base_url' => env('LLAMA_API_URL'),
+        'api_key' => env('LLAMA_API_KEY'),
+    ],
+];


### PR DESCRIPTION
This PR introduces support for selecting a custom AI engine (e.g., self-hosted Llama) alongside OpenAI. Key changes:

1. Created config/ai.php to define the active engine (AI_ENGINE) and credentials/settings for both OpenAI and Llama endpoints.
2. Added App\Services\AiService to abstract chat and audio transcription calls. It delegates to the configured engine: OpenAI via the existing facade, or Llama via HTTP requests.
3. Updated all AI-related Actions (GenerateSubtitles, TranslateSubtitles, GenerateChapters, GenerateSummary) to inject and use AiService instead of directly calling the OpenAI facade.

With these changes, you can now set AI_ENGINE=openai or AI_ENGINE=llama in your .env (along with LLAMA_API_URL and LLAMA_API_KEY) to switch between providers seamlessly.

Closes #33