### PR TITLE
Add optional TwelveLabs Pegasus provider (subtitles + summary + chapters in one call)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,26 @@ Your video is sent to an API where the audio is extracted from it using FFMpeg, 
 
 If you chose to select chapters or a summary, that transcript is then sent to a **ChatGPT model** for processing into concise chapters of the length you wanted, and a brief summary that would fit in something like a YouTube description.
 
+### Using TwelveLabs instead of OpenAI (optional)
+
+Subvert can also process videos with [TwelveLabs](https://twelvelabs.io)' **Pegasus** model instead of OpenAI. Pegasus understands video directly, so the same subtitles, summary, and chapters are produced from a single video-native analysis call — no separate audio extraction, Whisper transcription, or ChatGPT round-trips.
+
+To opt in, set `AI_PROVIDER=twelvelabs` and provide a `TWELVELABS_API_KEY`:
+
+```
+docker run -it -p 80:8080 -e AI_PROVIDER=twelvelabs -e TWELVELABS_API_KEY=tlk-123abc aschmelyun/subvert
+```
+
+The default provider remains OpenAI, so existing setups are unaffected. You can grab a free API key at [twelvelabs.io](https://twelvelabs.io) — there's a generous free tier.
+
 ## Configuration
 
 You can adjust a few parameters in the container by passing in [environment variables](https://docs.docker.com/engine/reference/commandline/run/#env) with your command using additional `-e` flags. Here are the current ones you can add:
 
-- `OPENAI_API_KEY` **(required)** - Sets the key responsible for communication with OpenAI's APIs. No default.
+- `OPENAI_API_KEY` **(required for the default OpenAI provider)** - Sets the key responsible for communication with OpenAI's APIs. No default.
+- `AI_PROVIDER` - Which provider processes videos: `openai` (default) or `twelvelabs`.
+- `TWELVELABS_API_KEY` **(required when `AI_PROVIDER=twelvelabs`)** - Key for TwelveLabs' API. No default.
+- `TWELVELABS_MODEL` - TwelveLabs analysis model. Default: `pegasus1.5`
 - `UPLOAD_MAX_FILESIZE` - Changes PHP's UPLOAD_MAX_FILESIZE setting. Default: `256M`
 - `MEMORY_LIMIT` - Changes PHP's MEMORY_LIMIT setting. Default: `512M`
 

--- a/src/.env.example
+++ b/src/.env.example
@@ -5,6 +5,12 @@ APP_DEBUG=true
 APP_URL=http://localhost
 APP_VERSION=1.0.9
 
+# AI provider. "openai" (default) uses Whisper + ChatGPT. Set to "twelvelabs"
+# to process videos with the Pegasus model instead (requires TWELVELABS_API_KEY).
+AI_PROVIDER=openai
+TWELVELABS_API_KEY=
+# TWELVELABS_MODEL=pegasus1.5
+
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug

--- a/src/app/Actions/AnalyzeWithTwelveLabs.php
+++ b/src/app/Actions/AnalyzeWithTwelveLabs.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\Status;
+use App\Models\Process;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Opt-in alternative to the OpenAI pipeline.
+ *
+ * Where the default flow extracts audio, transcribes with Whisper, then makes
+ * several ChatGPT calls for chapters and a summary, this action sends the video
+ * straight to TwelveLabs' Pegasus model and gets subtitles, a summary, and
+ * chapters back from a single video-native analysis call.
+ *
+ * It only runs when the `twelvelabs` provider is selected (TWELVELABS_API_KEY
+ * set + AI_PROVIDER=twelvelabs, or the per-request `provider` option). When it
+ * runs it fully populates the process and marks it complete, so the downstream
+ * OpenAI actions are skipped. Otherwise it is a transparent pass-through.
+ */
+class AnalyzeWithTwelveLabs
+{
+    public function handle(Process $process, \Closure $next)
+    {
+        if (! $this->shouldRun($process)) {
+            return $next($process);
+        }
+
+        try {
+            $assetId = $this->uploadAsset($process);
+
+            $analysis = $this->analyze($process, $assetId);
+
+            $process->update([
+                'transcript' => $analysis['subtitles'] ?? null,
+                'summary' => $this->wants($process, 'summary') ? ($analysis['summary'] ?? null) : null,
+                'chapters' => $this->wants($process, 'chapters') ? $this->formatChapters($analysis['chapters'] ?? []) : null,
+                'status' => Status::COMPLETE,
+            ]);
+        } catch (\Throwable $e) {
+            $process->update([
+                'status' => Status::ERRORED,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        // This provider produces everything in one call, so we deliberately do
+        // not pass the process down to the OpenAI actions.
+        return;
+    }
+
+    private function shouldRun(Process $process): bool
+    {
+        if (! config('services.twelvelabs.api_key')) {
+            return false;
+        }
+
+        $provider = $process->options['provider'] ?? env('AI_PROVIDER', 'openai');
+
+        return $provider === 'twelvelabs';
+    }
+
+    private function wants(Process $process, string $option): bool
+    {
+        return filter_var($process->options[$option] ?? false, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    private function client(): PendingRequest
+    {
+        return Http::baseUrl(config('services.twelvelabs.base_url'))
+            ->withHeaders(['x-api-key' => config('services.twelvelabs.api_key')])
+            ->timeout(600);
+    }
+
+    /**
+     * Upload the stored video as a TwelveLabs asset and wait for it to be ready.
+     */
+    private function uploadAsset(Process $process): string
+    {
+        $process->update(['status' => Status::EXTRACTING_AUDIO]);
+
+        $path = storage_path("app/{$process->file}");
+
+        $response = $this->client()
+            ->attach('file', fopen($path, 'r'), basename($path))
+            ->post('/assets', ['method' => 'direct'])
+            ->throw()
+            ->json();
+
+        $assetId = $response['_id'] ?? null;
+        if (! $assetId) {
+            throw new \RuntimeException('TwelveLabs did not return an asset id.');
+        }
+
+        $deadline = now()->addMinutes(10);
+        do {
+            $asset = $this->client()->get("/assets/{$assetId}")->throw()->json();
+            $status = $asset['status'] ?? 'processing';
+
+            if ($status === 'ready') {
+                return $assetId;
+            }
+
+            if ($status === 'failed') {
+                throw new \RuntimeException('TwelveLabs failed to process the uploaded asset.');
+            }
+
+            sleep(5);
+        } while (now()->lessThan($deadline));
+
+        throw new \RuntimeException('Timed out waiting for the TwelveLabs asset to become ready.');
+    }
+
+    /**
+     * Run a single Pegasus analysis that returns subtitles, a summary, and
+     * chapters as structured JSON.
+     */
+    private function analyze(Process $process, string $assetId): array
+    {
+        $process->update(['status' => Status::PROCESSING_SUBTITLES]);
+
+        $language = ($process->options['language'] ?? 'default');
+        $language = $language === 'default' ? 'the original spoken language' : $language;
+        $chaptersAmount = (int) ($process->options['chapters_amount'] ?? 5);
+
+        $prompt = "Watch the video and return: (1) word-for-word subtitles in {$language} as an array "
+            . "of cues, each with start and end timestamps in seconds and the spoken text; "
+            . "(2) a concise summary of no more than 5 sentences that would fit a video description; "
+            . "(3) exactly {$chaptersAmount} chapters spread evenly across the video, each with a start "
+            . "timestamp in seconds and a short title.";
+
+        $schema = [
+            'type' => 'object',
+            'properties' => [
+                'subtitles' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'start' => ['type' => 'number'],
+                            'end' => ['type' => 'number'],
+                            'text' => ['type' => 'string'],
+                        ],
+                        'required' => ['start', 'end', 'text'],
+                    ],
+                ],
+                'summary' => ['type' => 'string'],
+                'chapters' => [
+                    'type' => 'array',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'start' => ['type' => 'number'],
+                            'title' => ['type' => 'string'],
+                        ],
+                        'required' => ['start', 'title'],
+                    ],
+                ],
+            ],
+            'required' => ['subtitles', 'summary', 'chapters'],
+        ];
+
+        $response = $this->client()->post('/analyze', [
+            'model_name' => config('services.twelvelabs.model'),
+            'video' => ['type' => 'asset_id', 'asset_id' => $assetId],
+            'prompt' => $prompt,
+            'temperature' => 0.2,
+            'max_tokens' => 4096,
+            'stream' => false,
+            'response_format' => [
+                'type' => 'json_schema',
+                'json_schema' => ['name' => 'subvert_analysis', 'schema' => $schema],
+            ],
+        ])->throw()->json();
+
+        $data = json_decode($response['data'] ?? '{}', true);
+
+        return [
+            'subtitles' => $this->toVtt($data['subtitles'] ?? []),
+            'summary' => $data['summary'] ?? null,
+            'chapters' => $data['chapters'] ?? [],
+        ];
+    }
+
+    /**
+     * Render Pegasus subtitle cues as a WebVTT document (the format the rest of
+     * Subvert already stores and downloads).
+     */
+    private function toVtt(array $cues): string
+    {
+        $lines = ['WEBVTT', ''];
+
+        foreach ($cues as $cue) {
+            if (! isset($cue['start'], $cue['end'], $cue['text'])) {
+                continue;
+            }
+
+            $lines[] = $this->timestamp($cue['start']) . ' --> ' . $this->timestamp($cue['end']);
+            $lines[] = trim($cue['text']);
+            $lines[] = '';
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function timestamp(float $seconds): string
+    {
+        $hours = floor($seconds / 3600);
+        $minutes = floor(($seconds - $hours * 3600) / 60);
+        $secs = $seconds - $hours * 3600 - $minutes * 60;
+
+        return sprintf('%02d:%02d:%06.3f', $hours, $minutes, $secs);
+    }
+
+    /**
+     * Match the plain-text "timestamp + title" chapter format used by the
+     * OpenAI chapters action.
+     */
+    private function formatChapters(array $chapters): string
+    {
+        $lines = [];
+
+        foreach ($chapters as $chapter) {
+            if (! isset($chapter['start'], $chapter['title'])) {
+                continue;
+            }
+
+            $lines[] = $this->timestamp($chapter['start']) . ' ' . trim($chapter['title']);
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/src/app/Jobs/ProcessVideo.php
+++ b/src/app/Jobs/ProcessVideo.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Actions\AnalyzeWithTwelveLabs;
 use App\Actions\ExtractAudio;
 use App\Actions\{GenerateSubtitles, GenerateChapters, GenerateSummary};
 use App\Actions\TranslateSubtitles;
@@ -36,6 +37,7 @@ class ProcessVideo implements ShouldQueue
         app(Pipeline::class)
             ->send($this->process)
             ->through([
+                AnalyzeWithTwelveLabs::class,
                 ExtractAudio::class,
                 GenerateSubtitles::class,
                 TranslateSubtitles::class,

--- a/src/config/services.php
+++ b/src/config/services.php
@@ -31,4 +31,10 @@ return [
         'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
     ],
 
+    'twelvelabs' => [
+        'api_key' => env('TWELVELABS_API_KEY'),
+        'base_url' => env('TWELVELABS_BASE_URL', 'https://api.twelvelabs.io/v1.3'),
+        'model' => env('TWELVELABS_MODEL', 'pegasus1.5'),
+    ],
+
 ];

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/src/tests/Feature/AnalyzeWithTwelveLabsTest.php
+++ b/src/tests/Feature/AnalyzeWithTwelveLabsTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\AnalyzeWithTwelveLabs;
+use App\Enums\Status;
+use App\Models\Process;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AnalyzeWithTwelveLabsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function process(array $options = []): Process
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('video/sample.mp4', 'fake-bytes');
+
+        return Process::create([
+            'options' => array_merge([
+                'provider' => 'twelvelabs',
+                'subtitles' => true,
+                'summary' => true,
+                'chapters' => true,
+                'chapters_amount' => 2,
+                'language' => 'default',
+            ], $options),
+            'file' => 'video/sample.mp4',
+        ]);
+    }
+
+    public function test_it_passes_through_when_no_api_key_is_configured(): void
+    {
+        config(['services.twelvelabs.api_key' => null]);
+        Http::fake();
+
+        $process = $this->process();
+        $reached = false;
+
+        (new AnalyzeWithTwelveLabs)->handle($process, function ($p) use (&$reached) {
+            $reached = true;
+
+            return $p;
+        });
+
+        $this->assertTrue($reached, 'OpenAI pipeline should continue when TwelveLabs is not configured.');
+        Http::assertNothingSent();
+    }
+
+    public function test_it_passes_through_when_provider_is_openai(): void
+    {
+        config(['services.twelvelabs.api_key' => 'tl-test']);
+        Http::fake();
+
+        $process = $this->process(['provider' => 'openai']);
+        $reached = false;
+
+        (new AnalyzeWithTwelveLabs)->handle($process, function ($p) use (&$reached) {
+            $reached = true;
+
+            return $p;
+        });
+
+        $this->assertTrue($reached);
+        Http::assertNothingSent();
+    }
+
+    public function test_it_produces_vtt_summary_and_chapters_in_one_pass(): void
+    {
+        config([
+            'services.twelvelabs.api_key' => 'tl-test',
+            'services.twelvelabs.base_url' => 'https://api.twelvelabs.io/v1.3',
+            'services.twelvelabs.model' => 'pegasus1.5',
+        ]);
+
+        Http::fake([
+            '*/assets' => Http::response(['_id' => 'asset-123', 'status' => 'processing'], 201),
+            '*/assets/asset-123' => Http::response(['_id' => 'asset-123', 'status' => 'ready'], 200),
+            '*/analyze' => Http::response([
+                'data' => json_encode([
+                    'subtitles' => [
+                        ['start' => 0, 'end' => 2.5, 'text' => 'Hello world'],
+                        ['start' => 2.5, 'end' => 5, 'text' => 'Second line'],
+                    ],
+                    'summary' => 'A short clip that greets the world.',
+                    'chapters' => [
+                        ['start' => 0, 'title' => 'Intro'],
+                        ['start' => 2.5, 'title' => 'Greeting'],
+                    ],
+                ]),
+            ], 200),
+        ]);
+
+        $process = $this->process();
+        $next = fn ($p) => $this->fail('TwelveLabs should short-circuit the OpenAI pipeline.');
+
+        (new AnalyzeWithTwelveLabs)->handle($process, $next);
+
+        $process->refresh();
+
+        $this->assertEquals(Status::COMPLETE, $process->status);
+        $this->assertStringStartsWith('WEBVTT', $process->transcript);
+        $this->assertStringContainsString('00:00:00.000 --> 00:00:02.500', $process->transcript);
+        $this->assertStringContainsString('Hello world', $process->transcript);
+        $this->assertEquals('A short clip that greets the world.', $process->summary);
+        $this->assertStringContainsString('00:00:00.000 Intro', $process->chapters);
+        $this->assertStringContainsString('00:00:02.500 Greeting', $process->chapters);
+    }
+
+    public function test_it_omits_summary_and_chapters_when_not_requested(): void
+    {
+        config(['services.twelvelabs.api_key' => 'tl-test']);
+
+        Http::fake([
+            '*/assets' => Http::response(['_id' => 'a1', 'status' => 'ready'], 201),
+            '*/assets/a1' => Http::response(['_id' => 'a1', 'status' => 'ready'], 200),
+            '*/analyze' => Http::response([
+                'data' => json_encode([
+                    'subtitles' => [['start' => 0, 'end' => 1, 'text' => 'Hi']],
+                    'summary' => 'unwanted',
+                    'chapters' => [['start' => 0, 'title' => 'unwanted']],
+                ]),
+            ], 200),
+        ]);
+
+        $process = $this->process(['summary' => false, 'chapters' => false]);
+
+        (new AnalyzeWithTwelveLabs)->handle($process, fn ($p) => $p);
+
+        $process->refresh();
+
+        $this->assertNull($process->summary);
+        $this->assertNull($process->chapters);
+        $this->assertStringContainsString('Hi', $process->transcript);
+    }
+
+    public function test_it_marks_the_process_errored_on_api_failure(): void
+    {
+        config(['services.twelvelabs.api_key' => 'tl-test']);
+
+        Http::fake([
+            '*/assets' => Http::response(['message' => 'bad request'], 400),
+        ]);
+
+        $process = $this->process();
+
+        (new AnalyzeWithTwelveLabs)->handle($process, fn ($p) => $p);
+
+        $process->refresh();
+
+        $this->assertEquals(Status::ERRORED, $process->status);
+        $this->assertNotEmpty($process->error);
+    }
+}

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,16 @@
 #!/bin/sh
 
-if [ -z "$OPENAI_API_KEY" ]; then
+if [ -z "$AI_PROVIDER" ]; then
+    AI_PROVIDER="openai"
+fi
+
+if [ "$AI_PROVIDER" = "openai" ] && [ -z "$OPENAI_API_KEY" ]; then
     echo "OPENAI_API_KEY is not set"
+    exit 1
+fi
+
+if [ "$AI_PROVIDER" = "twelvelabs" ] && [ -z "$TWELVELABS_API_KEY" ]; then
+    echo "TWELVELABS_API_KEY is not set"
     exit 1
 fi
 
@@ -13,8 +22,16 @@ if [ -z "$MEMORY_LIMIT" ]; then
     MEMORY_LIMIT="512M"
 fi
 
-# Only add this line if it's not present in the .env file
-grep -qxF "OPENAI_API_KEY=$OPENAI_API_KEY" .env || echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
+# Only add these lines if they're not present in the .env file
+grep -qxF "AI_PROVIDER=$AI_PROVIDER" .env || echo "AI_PROVIDER=$AI_PROVIDER" >> .env
+
+if [ -n "$OPENAI_API_KEY" ]; then
+    grep -qxF "OPENAI_API_KEY=$OPENAI_API_KEY" .env || echo "OPENAI_API_KEY=$OPENAI_API_KEY" >> .env
+fi
+
+if [ -n "$TWELVELABS_API_KEY" ]; then
+    grep -qxF "TWELVELABS_API_KEY=$TWELVELABS_API_KEY" .env || echo "TWELVELABS_API_KEY=$TWELVELABS_API_KEY" >> .env
+fi
 
 # Only add these lines if they're not present in the php.ini file
 grep -qxF "memory_limit = $MEMORY_LIMIT" /usr/local/etc/php/php.ini || echo "memory_limit = $MEMORY_LIMIT" >> /usr/local/etc/php/php.ini


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This adds an **optional** TwelveLabs Pegasus provider as an alternative to the OpenAI pipeline.

### What it adds
- A new `AnalyzeWithTwelveLabs` pipeline action that sends the uploaded video straight to TwelveLabs' **Pegasus** model and gets **subtitles (WebVTT), a summary, and chapters back from a single video-native analysis call** — no separate audio extraction, Whisper transcription, or multiple ChatGPT round-trips.
- It uploads the stored file as a TwelveLabs asset, polls until it's ready, then runs one structured-JSON `analyze` request. Subtitle cues are rendered to the same WebVTT format Subvert already stores/downloads, and chapters use the same `timestamp title` plain-text format as the existing OpenAI action, so the rest of the app (views, downloads) works unchanged.
- Honors the existing `summary`, `chapters`, `chapters_amount`, and `language` options.

### Why it helps
Pegasus understands video directly, so the whole job (subtitles + summary + chapters) is one call instead of audio extraction + Whisper + several ChatGPT calls. It's also a drop-in second provider for anyone who'd rather not use OpenAI.

### Opt-in / non-breaking
- Default provider stays `openai`; existing setups and behavior are unchanged.
- Enabled only when `AI_PROVIDER=twelvelabs` **and** `TWELVELABS_API_KEY` is set (or a per-request `provider: twelvelabs` option). When inactive the new action is a transparent pass-through that calls `$next($process)`.
- `startup.sh` now requires `OPENAI_API_KEY` only for the OpenAI provider and `TWELVELABS_API_KEY` only for the TwelveLabs provider.
- Wired via `config/services.php` + env vars, the same way the existing OpenAI config works. No new Composer dependency — uses the bundled Laravel HTTP client.

### How it was tested
- Added `tests/Feature/AnalyzeWithTwelveLabsTest.php`: no-network tests using `Http::fake()` covering pass-through (no key / `openai` provider), the full upload→poll→analyze→VTT/summary/chapters flow, option gating, and the API-error path. (Uncommented the already-present sqlite `:memory:` lines in `phpunit.xml` so feature tests can hit the DB.)
- The asset-upload, asset-status, and analyze request/response shapes were verified against the official TwelveLabs Python SDK source and live API endpoint probes. Auth was confirmed against the live API. Full server-side Pegasus run is wiring-verified; I couldn't complete an end-to-end public-URL run from my sandbox (the TwelveLabs ingest worker couldn't fetch my test URLs), so the network flow is exercised via faked HTTP in the test suite.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.